### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,9 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "namedInputs": {
-    "terraform-files": ["{projectRoot}/**/*.tf"],
+    "terraform-files": [
+      "{projectRoot}/**/*.tf"
+    ],
     "terraform-init-outputs": [
       "{projectRoot}/.terraform",
       "{projectRoot}/.terraform.lock.hcl"
@@ -40,23 +42,37 @@
     },
     "terraform-plan": {
       "executor": "nx:run-commands",
-      "dependsOn": ["terraform-init"],
-      "inputs": ["terraform-all"],
+      "dependsOn": [
+        "terraform-init"
+      ],
+      "inputs": [
+        "terraform-all"
+      ],
       "options": {
         "cwd": "{projectRoot}",
         "command": "terraform plan",
-        "args": ["-out=tfplan"]
+        "args": [
+          "-out=tfplan"
+        ]
       }
     },
     "terraform-apply": {
       "executor": "nx:run-commands",
-      "dependsOn": ["terraform-plan"],
-      "inputs": ["terraform-all"],
+      "dependsOn": [
+        "terraform-plan"
+      ],
+      "inputs": [
+        "terraform-all"
+      ],
       "options": {
         "cwd": "{projectRoot}",
         "command": "terraform apply",
-        "args": ["-auto-approve", "tfplan"]
+        "args": [
+          "-auto-approve",
+          "tfplan"
+        ]
       }
     }
-  }
+  },
+  "nxCloudId": "686e975426cf276f670bc399"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/686e96ff85cba1b0db8a68f3/workspaces/686e975426cf276f670bc399

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.